### PR TITLE
Extend lib with general utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2
+
+- Add general utils
+- Add version of OS
+
 ## 1.0.1
 
 - Remove babel-polyfill from bundle.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Wrapper for bowser library with a custom API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/general-utils/get-version.js
+++ b/src/general-utils/get-version.js
@@ -1,0 +1,5 @@
+const getVersion = (parser) => {
+  return parser.getOSVersion();
+};
+
+export default getVersion;

--- a/src/general-utils/get-version.js
+++ b/src/general-utils/get-version.js
@@ -1,5 +1,3 @@
-const getVersion = (parser) => {
-  return parser.getOSVersion();
-};
+const getVersion = (parser) => parser.getOSVersion();
 
 export default getVersion;

--- a/src/general-utils/get-version.spec.js
+++ b/src/general-utils/get-version.spec.js
@@ -1,0 +1,13 @@
+import getVersion from './get-version.js';
+
+const getParserMock = () => ({
+  getOSVersion: jest.fn(() => 12)
+});
+
+describe('getVersion', () => {
+  it('should return version of OS', () => {
+    const mock = getParserMock();
+    expect(getVersion(mock)).toEqual(12);
+    expect(mock.getOSVersion).toHaveBeenCalled();
+  });
+});

--- a/src/general-utils/index.js
+++ b/src/general-utils/index.js
@@ -1,0 +1,5 @@
+import getVersion from './get-version';
+
+export default {
+  getVersion,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import Bowser from 'bowser';
 import browserUtils from './browser-utils';
 import osUtils from './os-utils';
 import platformUtils from './platform-utils';
+import generalUtils from './general-utils';
 
 const parser = Bowser.getParser(window.navigator.userAgent || '');
 
@@ -27,4 +28,7 @@ export default {
   mobile: platformUtils.isMobile(parser),
   tablet: platformUtils.isTablet(parser) || osUtils.isIpadOS(parser),
   desktop: platformUtils.isDesktop(parser) && !osUtils.isIpadOS(parser),
+
+  // General utils
+  version: generalUtils.getVersion(parser),
 };

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2,16 +2,17 @@ import browserTypes from './constants/browser-types';
 import osTypes from './constants/os-types';
 import platformTypes from './constants/platform-types';
 
-const getBowserMock = ({ browser, os, platform }) => ({
+const getBowserMock = ({ browser, os, platform, version }) => ({
   getParser: jest.fn(() => ({
     getBrowserName: jest.fn(() => browser),
     getOSName: jest.fn(() => os),
     getPlatformType: jest.fn(() => platform),
+    getOSVersion: jest.fn(() => version),
   }))
-})
+});
 
-const setup = ({ browser, os, platform }) => {
-  const mockBowser = getBowserMock({ browser, os, platform });
+const setup = ({ browser, os, platform, version }) => {
+  const mockBowser = getBowserMock({ browser, os, platform, version });
   jest.mock('bowser', () => mockBowser);
 
   // eslint-disable-next-line global-require
@@ -164,4 +165,12 @@ describe('yola-bowser: ', () => {
       });
     });
   });
+  describe('General Utils', () => {
+    describe('version', () => {
+      it('should return version of OS', () => {
+        yolaBowser = setup({ version: '12.2.1' });
+        expect(yolaBowser.version).toEqual('12.2.1');
+      });
+    });
+  })
 });


### PR DESCRIPTION
issue [https://github.com/yola/production/issues/6739](https://github.com/yola/production/issues/6739)
To fix the bug we should know which version of a browser we are using at the moment. This PR extends lib with the return version of OS. 