### PR TITLE
Add `isChromeOS` os-util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- add `isChromeOS` os-util
+
 ## 1.1.1
 
 - fix of `satisfies` method

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ const isMobile = yolaBowser.mobile;
 * `linux`
 * `macOS` - Desktop Mac, but not the new iPad OS.
 * `windows`
+* `chromeOS`
 
 ### Platform flags:
 * `mobile` - All detected mobile OSes, unless it's a tablet.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.2.0-rc.sereezha.1",
+  "version": "1.2.0-rc.sereezha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.2.0-rc.sereezha.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.2.0",
+  "version": "1.2.0-rc.sereezha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.2.0-rc.sereezha.1",
+  "version": "1.2.0-rc.sereezha.2",
   "description": "Wrapper for bowser library with a custom API",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.2.0-rc.sereezha.2",
+  "version": "1.2.0",
   "description": "Wrapper for bowser library with a custom API",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Wrapper for bowser library with a custom API",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yola-bowser",
-  "version": "1.2.0",
+  "version": "1.2.0-rc.sereezha.1",
   "description": "Wrapper for bowser library with a custom API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/constants/os-types.js
+++ b/src/constants/os-types.js
@@ -7,4 +7,5 @@ export default {
   LINUX: 'Linux',
   MACOS: 'macOS',
   WINDOWS: 'Windows',
+  CHROME_OS: 'Chrome OS',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export default {
   linux: osUtils.isLinux(parser),
   macOS: osUtils.isMacOS(parser) && !osUtils.isIpadOS(parser),
   windows: osUtils.isWindows(parser),
+  chromeOS: osUtils.isChromeOS(parser),
 
   // Platform flags
   mobile: platformUtils.isMobile(parser),

--- a/src/os-utils/index.js
+++ b/src/os-utils/index.js
@@ -4,6 +4,7 @@ import isIpadOS from './is-ipad-os';
 import isLinux from './is-linux';
 import isMacOS from './is-macos';
 import isWindows from './is-windows';
+import isChromeOS from './is-chrome-os';
 
 export default {
   isAndroid,
@@ -12,4 +13,5 @@ export default {
   isLinux,
   isMacOS,
   isWindows,
+  isChromeOS
 };

--- a/src/os-utils/is-chrome-os.js
+++ b/src/os-utils/is-chrome-os.js
@@ -1,0 +1,8 @@
+import osTypes from '../constants/os-types';
+
+const isChromeOS = (parser) => {
+  const osType = parser.getOSName();
+  return osType === osTypes.CHROME_OS;
+};
+
+export default isChromeOS;

--- a/src/os-utils/is-chrome-os.spec.js
+++ b/src/os-utils/is-chrome-os.spec.js
@@ -1,0 +1,24 @@
+import osTypes from '../constants/os-types';
+import isChromeOS from './is-chrome-os';
+
+const getParserMock = (osName) => ({
+  getOSName: jest.fn(() => osName),
+});
+
+describe('isChromeOS', () => {
+  describe('when OS is ChromeOS', () => {
+    it('should return true', () => {
+      const mock = getParserMock(osTypes.CHROME_OS);
+      expect(isChromeOS(mock)).toEqual(true);
+      expect(mock.getOSName).toHaveBeenCalled();
+    });
+  });
+
+  describe('when OS is not ChromeOS', () => {
+    it('should return false', () => {
+      const mock = getParserMock(osTypes.WINDOWS);
+      expect(isChromeOS(mock)).toEqual(false);
+      expect(mock.getOSName).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
issue: https://github.com/yola/ws-editor/issues/4297
env: https://editor.hto-ya.env.yola.net/

## How to test
1. Go to [editor](https://editor.hto-ya.env.yola.net/)
### Expected result
- if OS is ChromeOS:
   - in the header you should see `!!!!!CHROME OS!!!!!` label (just for test purposes)
- if OS is NOT ChromeOS:
   - in the header you should see `!!!!!OTHER OS!!!!!` label (just for test purposes)